### PR TITLE
ログメッセージにスタックトレースを表示

### DIFF
--- a/fmodules/logging_wrappers.py
+++ b/fmodules/logging_wrappers.py
@@ -24,6 +24,8 @@ class fFormatter(Formatter):
         msgs = [lv, time, mod, msg]
         if rec.levelno in (DEBUG, ERROR, CRITICAL):
             msgs.append(f"({rec.lineno}:{rec.funcName})")
+        if rec.stack_info:
+            msgs.append(f"\n{self.formatStack(rec.stack_info)}")
         return " ".join(msgs)
 
 

--- a/fmodules/tests/raise_zero_div.py
+++ b/fmodules/tests/raise_zero_div.py
@@ -1,0 +1,13 @@
+"""
+This file is only used in "test_logging_wrappers".
+"""
+
+from logging import Logger
+from ..logging_wrappers import getLogger
+
+logger: Logger = getLogger()
+
+
+def raise_zero_div():
+    logger.error("zero div", stack_info=True)
+    1 / 0

--- a/fmodules/tests/test_logging_wrappers.py
+++ b/fmodules/tests/test_logging_wrappers.py
@@ -1,21 +1,73 @@
+from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, LogRecord, Formatter
 import pytest
 from pathlib import Path
-import re
-from ..logging_wrappers import getLogger
+from time import strftime, localtime
+from ..logging_wrappers import getLogger, fFormatter
+from .. import logging_wrappers
 
-from . import any_module
+from . import any_module, raise_zero_div
+
+
+@pytest.fixture
+def created_time(mocker) -> None:
+    # `logging.time.time()` will be assigned to `LogRecord.created` attribute.
+    # Therefore, log messages' asctime will be fixed.
+    ctime = 1000000000
+    mocker.patch("logging.time.time", return_value=ctime)
+    return strftime("%Y-%m-%d %X", localtime(ctime))
+
+
+class Test_fFormatter:
+    class Test_format:
+        @pytest.fixture
+        def fmt(self) -> fFormatter:
+            return fFormatter()
+
+        @pytest.mark.parametrize("lv_no, lv_name", [(INFO, "INFO"), (WARNING, "WARNING")])
+        def test_OutputMsg_TakesSpecificLevel(self, fmt: fFormatter, created_time, lv_no, lv_name):
+            rec = LogRecord("name", lv_no, "pathname", 100, "msg", None, None, func="func")
+            assert fmt.format(rec) == f"{lv_name:>8} {created_time} [pathname] msg"
+
+        @pytest.mark.parametrize("lv_no, lv_name", [(DEBUG, "DEBUG"), (ERROR, "ERROR"), (CRITICAL, "CRITICAL")])
+        def test_OutputLineNoAndFuncName_TakesSpecificLevel(self, fmt: fFormatter, created_time, lv_no, lv_name):
+            rec = LogRecord("name", lv_no, "pathname", 100, "msg", None, None, func="func")
+            assert fmt.format(rec) == f"{lv_name:>8} {created_time} [pathname] msg (100:func)"
+
+        def test_OutputStackTrace_SInfoIsStr(self, fmt: fFormatter, created_time):
+            rec = LogRecord("name", ERROR, "pathname", 100, "msg", None, None, func="func", sinfo="sinfo")
+            assert fmt.format(rec) == f"   ERROR {created_time} [pathname] msg (100:func) \nsinfo"
+
+        def test_OutputRoot_RootIsNotRecModule(self, fmt: fFormatter, created_time, mocker):
+            mocker.patch.object(logging_wrappers, "_root", new="_root")
+            rec = LogRecord("name", INFO, "pathname", 100, "msg", None, None, func="func")
+            assert fmt.format(rec) == f"    INFO {created_time} [_root.pathname] msg"
 
 
 class Test_getLogger:
-    def test_LoggersInOtherModulesWillLogWithMyName_PassedTrueToRoot(self, capfd):
+    def test_LoggersInOtherModulesWillLogWithMyName_PassedTrueToRoot(self, capfd, created_time):
         getLogger(root=True)
         any_module.log("test")
         out, _ = capfd.readouterr()
-        assert re.search(r"\[" + Path(__file__).stem + r"\." + "any_module" + r"\]", out)
+        assert out == f"    INFO {created_time} [{Path(__file__).stem}.any_module] test\n"
 
-    def test_LoggersInOtherModulesWillLogWithRootName_PassedRootAndName(self, capfd):
+    def test_LoggersInOtherModulesWillLogWithRootName_PassedRootAndName(self, capfd, created_time):
         root_name = "hoge"
         getLogger(root=True, name=root_name)
         any_module.log("test")
         out, _ = capfd.readouterr()
-        assert re.search(r"\[" + root_name + r"\." + "any_module" + r"\]", out)
+        assert out == f"    INFO {created_time} [{root_name}.any_module] test\n"
+
+    def test_OutputStackTrace_ErrorRaised(self, capfd, mocker, created_time):
+        getLogger(root=True)
+        fmt_stack = mocker.spy(Formatter, "formatStack")
+        with pytest.raises(ZeroDivisionError):
+            raise_zero_div.raise_zero_div()
+        out, err = capfd.readouterr()
+        fmt_stack.assert_called()
+        expected = (
+            f"   ERROR {created_time} "
+            f"[{Path(__file__).stem}.raise_zero_div] zero div (12:raise_zero_div) \n"
+            "Stack (most recent call last):\n"
+        )
+        assert out.startswith(expected)
+        assert err.startswith(expected)

--- a/fmodules/tests/test_logging_wrappers.py
+++ b/fmodules/tests/test_logging_wrappers.py
@@ -9,7 +9,7 @@ from . import any_module, raise_zero_div
 
 
 @pytest.fixture
-def created_time(mocker) -> None:
+def fixed_time(mocker) -> None:
     # `logging.time.time()` will be assigned to `LogRecord.created` attribute.
     # Therefore, log messages' asctime will be fixed.
     ctime = 1000000000
@@ -24,40 +24,40 @@ class Test_fFormatter:
             return fFormatter()
 
         @pytest.mark.parametrize("lv_no, lv_name", [(INFO, "INFO"), (WARNING, "WARNING")])
-        def test_OutputMsg_TakesSpecificLevel(self, fmt: fFormatter, created_time, lv_no, lv_name):
+        def test_OutputMsg_TakesSpecificLevel(self, fmt: fFormatter, fixed_time, lv_no, lv_name):
             rec = LogRecord("name", lv_no, "pathname", 100, "msg", None, None, func="func")
-            assert fmt.format(rec) == f"{lv_name:>8} {created_time} [pathname] msg"
+            assert fmt.format(rec) == f"{lv_name:>8} {fixed_time} [pathname] msg"
 
         @pytest.mark.parametrize("lv_no, lv_name", [(DEBUG, "DEBUG"), (ERROR, "ERROR"), (CRITICAL, "CRITICAL")])
-        def test_OutputLineNoAndFuncName_TakesSpecificLevel(self, fmt: fFormatter, created_time, lv_no, lv_name):
+        def test_OutputLineNoAndFuncName_TakesSpecificLevel(self, fmt: fFormatter, fixed_time, lv_no, lv_name):
             rec = LogRecord("name", lv_no, "pathname", 100, "msg", None, None, func="func")
-            assert fmt.format(rec) == f"{lv_name:>8} {created_time} [pathname] msg (100:func)"
+            assert fmt.format(rec) == f"{lv_name:>8} {fixed_time} [pathname] msg (100:func)"
 
-        def test_OutputStackTrace_SInfoIsStr(self, fmt: fFormatter, created_time):
+        def test_OutputStackTrace_StackInfoIsStr(self, fmt: fFormatter, fixed_time):
             rec = LogRecord("name", ERROR, "pathname", 100, "msg", None, None, func="func", sinfo="sinfo")
-            assert fmt.format(rec) == f"   ERROR {created_time} [pathname] msg (100:func) \nsinfo"
+            assert fmt.format(rec) == f"   ERROR {fixed_time} [pathname] msg (100:func) \nsinfo"
 
-        def test_OutputRoot_RootIsNotRecModule(self, fmt: fFormatter, created_time, mocker):
+        def test_OutputRoot_RootIsNotRecModule(self, fmt: fFormatter, fixed_time, mocker):
             mocker.patch.object(logging_wrappers, "_root", new="_root")
             rec = LogRecord("name", INFO, "pathname", 100, "msg", None, None, func="func")
-            assert fmt.format(rec) == f"    INFO {created_time} [_root.pathname] msg"
+            assert fmt.format(rec) == f"    INFO {fixed_time} [_root.pathname] msg"
 
 
 class Test_getLogger:
-    def test_LoggersInOtherModulesWillLogWithMyName_PassedTrueToRoot(self, capfd, created_time):
+    def test_LoggersInOtherModulesWillLogWithMyName_PassedTrueToRoot(self, capfd, fixed_time):
         getLogger(root=True)
         any_module.log("test")
         out, _ = capfd.readouterr()
-        assert out == f"    INFO {created_time} [{Path(__file__).stem}.any_module] test\n"
+        assert out == f"    INFO {fixed_time} [{Path(__file__).stem}.any_module] test\n"
 
-    def test_LoggersInOtherModulesWillLogWithRootName_PassedRootAndName(self, capfd, created_time):
+    def test_LoggersInOtherModulesWillLogWithRootName_PassedRootAndName(self, capfd, fixed_time):
         root_name = "hoge"
         getLogger(root=True, name=root_name)
         any_module.log("test")
         out, _ = capfd.readouterr()
-        assert out == f"    INFO {created_time} [{root_name}.any_module] test\n"
+        assert out == f"    INFO {fixed_time} [{root_name}.any_module] test\n"
 
-    def test_OutputStackTrace_ErrorRaised(self, capfd, mocker, created_time):
+    def test_OutputStackTrace_ErrorRaised(self, capfd, mocker, fixed_time):
         getLogger(root=True)
         fmt_stack = mocker.spy(Formatter, "formatStack")
         with pytest.raises(ZeroDivisionError):
@@ -65,7 +65,7 @@ class Test_getLogger:
         out, err = capfd.readouterr()
         fmt_stack.assert_called()
         expected = (
-            f"   ERROR {created_time} "
+            f"   ERROR {fixed_time} "
             f"[{Path(__file__).stem}.raise_zero_div] zero div (12:raise_zero_div) \n"
             "Stack (most recent call last):\n"
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = fierte_modules
 author = FIERTE CORPORATION
 license = LICENSE
-version = 2.0.0
+version = 2.0.1
 description = Standard library extension or wrapper.
 
 [options]


### PR DESCRIPTION
#6 の対応です。

# before/after
## before
スタックトレースはログに出力されません
```py
    ERROR 2001-09-09 10:46:40 [test_logging_wrappers.raise_zero_div] zero div (12:raise_zero_div)
```

## after
スタックトレースがログに出力されます。
```py
    ERROR 2001-09-09 10:46:40 [test_logging_wrappers.raise_zero_div] zero div (12:raise_zero_div) 
Stack (most recent call last):
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Standard-Library-Extension\.venv\Scripts\pytest.exe\__main__.py", line 7, in <module>
    sys.exit(console_main())
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\config\__init__.py", line 185, in console_main
    code = main()
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\config\__init__.py", line 162, in main
    ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\main.py", line 316, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\main.py", line 269, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\main.py", line 323, in _main
    config.hook.pytest_runtestloop(session=session)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\main.py", line 348, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\runner.py", line 109, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\runner.py", line 126, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\runner.py", line 215, in call_and_report
    call = call_runtest_hook(item, when, **kwds)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\runner.py", line 254, in call_runtest_hook
    return CallInfo.from_call(
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\runner.py", line 311, in from_call
    result: Optional[TResult] = func()
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\runner.py", line 255, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\runner.py", line 162, in pytest_runtest_call
    item.runtest()
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\python.py", line 1641, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "C:\Standard-Library-Extension\.venv\lib\site-packages\_pytest\python.py", line 183, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "C:\Standard-Library-Extension\fmodules\tests\test_logging_wrappers.py", line 64, in test_OutputStackTrace_ErrorRaised
    raise_zero_div.raise_zero_div()
  File "C:\Standard-Library-Extension\fmodules\tests\raise_zero_div.py", line 12, in raise_zero_div
    logger.error("zero div", stack_info=True)
```

# その他の変更点
ログが出力された時間を固定するfixture`fixed_time`を作成しました。
これにより、`getLogger`で表示されるメッセージを時間込みで検証可能になりました。
既存のテストについても、ログの出力内容を全て検証できるように正規表現ではなく完全一致にしました。
- スタックトレースの内容については、完全一致させようとすると長くなるため`startswith`でテストしています。