### PR TITLE
ログメッセージが二重に出力される問題の解決

### DIFF
--- a/fmodules/logging_wrappers.py
+++ b/fmodules/logging_wrappers.py
@@ -16,7 +16,7 @@ _root: str = ""
 
 
 class LevelFilter:
-    def __init__(self, max_level):
+    def __init__(self, max_level: int):
         self.max_level = max_level
 
     def filter(self, record: LogRecord):
@@ -40,7 +40,7 @@ class fFormatter(Formatter):
 _fmt = fFormatter()
 
 
-def _MakeHandler(handler: type[Handler], min_level=NOTSET, max_level=CRITICAL, **kwargs) -> Handler:
+def _MakeHandler(handler: type[Handler], min_level: int = NOTSET, max_level: int = CRITICAL, **kwargs) -> Handler:
     hndl = handler(**kwargs)
     hndl.setLevel(min_level)
     hndl.setFormatter(_fmt)

--- a/fmodules/tests/any_module.py
+++ b/fmodules/tests/any_module.py
@@ -8,5 +8,17 @@ from ..logging_wrappers import getLogger
 logger: Logger = getLogger()
 
 
-def log(msg: str):
+def debug(msg: str):
+    logger.debug(msg)
+
+
+def info(msg: str):
     logger.info(msg)
+
+
+def warning(msg: str):
+    logger.warning(msg)
+
+
+def error(msg: str):
+    logger.error(msg)

--- a/fmodules/tests/any_module.py
+++ b/fmodules/tests/any_module.py
@@ -22,3 +22,7 @@ def warning(msg: str):
 
 def error(msg: str):
     logger.error(msg)
+
+
+def critical(msg: str):
+    logger.critical(msg)

--- a/fmodules/tests/test_logging_wrappers.py
+++ b/fmodules/tests/test_logging_wrappers.py
@@ -89,6 +89,13 @@ class Test_getLogger:
         assert out == ""
         assert err == f"   ERROR {fixed_time} [{Path(__file__).stem}.any_module] test (24:error)\n"
 
+    def test_OutputCriticalLog_TakesSpecificLevel(self, capfd, fixed_time):
+        getLogger(root=True)
+        any_module.critical("test")
+        out, err = capfd.readouterr()
+        assert out == ""
+        assert err == f"CRITICAL {fixed_time} [{Path(__file__).stem}.any_module] test (28:critical)\n"
+
     def test_LoggersInOtherModulesWillLogWithMyName_PassedTrueToRoot(self, capfd, fixed_time):
         getLogger(root=True)
         any_module.info("test")

--- a/fmodules/tests/test_logging_wrappers.py
+++ b/fmodules/tests/test_logging_wrappers.py
@@ -9,7 +9,7 @@ from . import any_module, raise_zero_div
 
 
 @pytest.fixture
-def fixed_time(mocker) -> None:
+def fixed_time(mocker) -> str:
     # `logging.time.time()` will be assigned to `LogRecord.created` attribute.
     # Therefore, log messages' asctime will be fixed.
     ctime = 1000000000
@@ -61,16 +61,44 @@ class Test_fFormatter:
 
 
 class Test_getLogger:
+    def test_OutputDebugLog_TakesSpecificLevel(self, capfd, fixed_time):
+        getLogger(root=True)
+        any_module.debug("test")
+        out, err = capfd.readouterr()
+        assert out == f"   DEBUG {fixed_time} [{Path(__file__).stem}.any_module] test (12:debug)\n"
+        assert err == ""
+
+    def test_OutputInfoLog_TakesSpecificLevel(self, capfd, fixed_time):
+        getLogger(root=True)
+        any_module.info("test")
+        out, err = capfd.readouterr()
+        assert out == f"    INFO {fixed_time} [{Path(__file__).stem}.any_module] test\n"
+        assert err == ""
+
+    def test_OutputWarningLog_TakesSpecificLevel(self, capfd, fixed_time):
+        getLogger(root=True)
+        any_module.warning("test")
+        out, err = capfd.readouterr()
+        assert out == ""
+        assert err == f" WARNING {fixed_time} [{Path(__file__).stem}.any_module] test\n"
+
+    def test_OutputErrorLog_TakesSpecificLevel(self, capfd, fixed_time):
+        getLogger(root=True)
+        any_module.error("test")
+        out, err = capfd.readouterr()
+        assert out == ""
+        assert err == f"   ERROR {fixed_time} [{Path(__file__).stem}.any_module] test (24:error)\n"
+
     def test_LoggersInOtherModulesWillLogWithMyName_PassedTrueToRoot(self, capfd, fixed_time):
         getLogger(root=True)
-        any_module.log("test")
+        any_module.info("test")
         out, _ = capfd.readouterr()
         assert out == f"    INFO {fixed_time} [{Path(__file__).stem}.any_module] test\n"
 
     def test_LoggersInOtherModulesWillLogWithRootName_PassedRootAndName(self, capfd, fixed_time):
         root_name = "hoge"
         getLogger(root=True, name=root_name)
-        any_module.log("test")
+        any_module.info("test")
         out, _ = capfd.readouterr()
         assert out == f"    INFO {fixed_time} [{root_name}.any_module] test\n"
 

--- a/fmodules/tests/test_logging_wrappers.py
+++ b/fmodules/tests/test_logging_wrappers.py
@@ -79,11 +79,12 @@ class Test_getLogger:
         fmt_stack = mocker.spy(Formatter, "formatStack")
         with pytest.raises(ZeroDivisionError):
             raise_zero_div.raise_zero_div()
-        _, err = capfd.readouterr()
+        out, err = capfd.readouterr()
         fmt_stack.assert_called()
         expected = (
             f"   ERROR {fixed_time} "
             f"[{Path(__file__).stem}.raise_zero_div] zero div (12:raise_zero_div) \n"
             "Stack (most recent call last):\n"
         )
+        assert out == ""
         assert err.startswith(expected)


### PR DESCRIPTION
#9 の対応です。

## 改修内容
- Handlerにどのレベルのログまでを出力対象とするかを設定する `LevelFilter` クラスを実装
- `sys.stdout`のFilterを設定するために引数を整理
- テストの実装と修正

二重に出力されていないことを確認したログ
```
PS C:\SLE_Logger_Test> python main.py
    INFO 2023-05-22 15:21:20 [main] INFO
 WARNING 2023-05-22 15:21:20 [main] WARNING
   ERROR 2023-05-22 15:21:20 [main] ERROR (10:main)
CRITICAL 2023-05-22 15:21:20 [main] CRITICAL (11:main)
```

## 影響範囲
ログのテストで `capfd` を用いていた場合、エラーになる可能性があります( `caplog` は問題なし)
`DEBUG`, `INFO` のテストの場合は`capfd.out`、 `WARNING`, `ERROR`のテストの場合は`capfd.err` でテストをしてください。