### PR TITLE
Streamに出力されるログレベルとファイルに出力されるログレベルを別々に設定

### DIFF
--- a/fmodules/logging_wrappers.py
+++ b/fmodules/logging_wrappers.py
@@ -64,7 +64,7 @@ def getLogger(output_dir: Optional[Path] = None, *, root: bool = False, name: st
     logger = gL(__package__)
     for hndl in list(logger.handlers):
         logger.removeHandler(hndl)
-    logger.setLevel(INFO if output_dir else DEBUG)
+    logger.setLevel(DEBUG)
     logger.addHandler(_MakeHandler(StreamHandler, min_level=DEBUG, max_level=INFO, stream=sys.stdout))
     logger.addHandler(_MakeHandler(StreamHandler, min_level=WARNING, stream=sys.stderr))
     if output_dir:

--- a/fmodules/logging_wrappers.py
+++ b/fmodules/logging_wrappers.py
@@ -65,12 +65,12 @@ def getLogger(output_dir: Optional[Path] = None, *, root: bool = False, name: st
     for hndl in list(logger.handlers):
         logger.removeHandler(hndl)
     logger.setLevel(DEBUG)
-    logger.addHandler(_MakeHandler(StreamHandler, min_level=DEBUG, max_level=INFO, stream=sys.stdout))
+    logger.addHandler(_MakeHandler(StreamHandler, min_level=INFO, max_level=INFO, stream=sys.stdout))
     logger.addHandler(_MakeHandler(StreamHandler, min_level=WARNING, stream=sys.stderr))
     if output_dir:
         log_dir = (output_dir / "log").mkdir_hidden()
         log_file = log_dir / f"{output_dir.resolve().name}.log"
-        logger.addHandler(_MakeHandler(FileHandler, filename=log_file, encoding="utf-8"))
+        logger.addHandler(_MakeHandler(FileHandler, filename=log_file, min_level=DEBUG, encoding="utf-8"))
     return logger
 
 

--- a/fmodules/tests/test_logging_wrappers.py
+++ b/fmodules/tests/test_logging_wrappers.py
@@ -61,12 +61,18 @@ class Test_fFormatter:
 
 
 class Test_getLogger:
-    def test_OutputDebugLog_TakesSpecificLevel(self, capfd, fixed_time):
+    def test_OutputDebugLog_TakesSpecificLevel(self, capfd):
         getLogger(root=True)
         any_module.debug("test")
         out, err = capfd.readouterr()
         assert out == ""
         assert err == ""
+
+    def test_WriteDebugLog_TakesSpecificLevel(self, fixed_time, tmp_path):
+        getLogger(tmp_path, root=True)
+        any_module.debug("test")
+        log_file = Path(tmp_path) / ".log" / f"{tmp_path.resolve().name}.log"
+        assert log_file.read_text() == f"   DEBUG {fixed_time} [{Path(__file__).stem}.any_module] test (12:debug)\n"
 
     def test_OutputInfoLog_TakesSpecificLevel(self, capfd, fixed_time):
         getLogger(root=True)

--- a/fmodules/tests/test_logging_wrappers.py
+++ b/fmodules/tests/test_logging_wrappers.py
@@ -65,7 +65,7 @@ class Test_getLogger:
         getLogger(root=True)
         any_module.debug("test")
         out, err = capfd.readouterr()
-        assert out == f"   DEBUG {fixed_time} [{Path(__file__).stem}.any_module] test (12:debug)\n"
+        assert out == ""
         assert err == ""
 
     def test_OutputInfoLog_TakesSpecificLevel(self, capfd, fixed_time):


### PR DESCRIPTION
#8 の対応です。

## 概要
- LOGGERが引数に依らず、`DEBUG`レベル以上のログを受け取るように改修
- Streamに出力するログレベルと、Fileに出力するログレベルを下記の通り変更
  - Stream: `INFO` ~ `CRITICAL`
  - File: `DEBUG` ~ `CRITICAL`

## 影響範囲
引数に依っては、下記の影響を受けます
- `Stream`に`DEBUG`レベルのログが流れないようになります
- `File`に`DEBUG`レベルのログが流れるようになります